### PR TITLE
Signin with slack support

### DIFF
--- a/lib/omniauth-slack/response_adapters/app_scoped_response_adapter.rb
+++ b/lib/omniauth-slack/response_adapters/app_scoped_response_adapter.rb
@@ -48,8 +48,11 @@ module OmniAuth
         @user_info ||= access_token.get(url).parsed
       end
 
+      # User ID is not guaranteed to be globally unique across all Slack users.
+      # The combination of user ID and team ID, on the other hand, is guaranteed
+      # to be globally unique.
       def uid
-        raw_info['user_id']
+        "#{raw_info['user_id']}-#{raw_info['team_id']}"
       end
     end
   end

--- a/lib/omniauth-slack/response_adapters/identity_scoped_response_adapter.rb
+++ b/lib/omniauth-slack/response_adapters/identity_scoped_response_adapter.rb
@@ -31,8 +31,11 @@ module OmniAuth
         @team_info ||= raw_info['team']
       end
 
+      # User ID is not guaranteed to be globally unique across all Slack users.
+      # The combination of user ID and team ID, on the other hand, is guaranteed
+      # to be globally unique.
       def uid
-        raw_info['user']['id']
+        "#{raw_info['user']['id']}-#{raw_info['team']['id']}"
       end
 
       def user_info


### PR DESCRIPTION
The PR makes the UID logic complaint with https://github.com/kmrshntr/omniauth-slack.
In the original code, `uid` was scoped by `team_id`, i.e:  https://github.com/kmrshntr/omniauth-slack/blob/master/lib/omniauth/strategies/slack.rb#L25
